### PR TITLE
Fix bug in resolution of time values dumped to H5MD output

### DIFF
--- a/hymd/file_io.py
+++ b/hymd/file_io.py
@@ -37,7 +37,7 @@ def setup_time_dependent_element(
 ):
     group = parent_group.create_group(name)
     step = group.create_dataset("step", (n_frames,), "int32")
-    time = group.create_dataset("time", (n_frames,), "int32")
+    time = group.create_dataset("time", (n_frames,), "float32")
     value = group.create_dataset("value", (n_frames, *shape), dtype)
     if units is not None:
         group.attrs["units"] = units


### PR DESCRIPTION
This essentially increases the resolution of the time outputted by the code in `/particles/all/<quantity>/time` from 1.0ps to 1e-45ps.

Closes #4 