### PR TITLE
Output the work done by the thermostat in H5MD output

### DIFF
--- a/hymd/file_io.py
+++ b/hymd/file_io.py
@@ -218,7 +218,7 @@ def store_static(
         h5md.thermostat_work_time,
         h5md.thermostat_work,
     ) = setup_time_dependent_element(
-        "thermostat_work", h5md.observables, n_frames, (3,), "float32", units="kJ/mol"
+        "thermostat_work", h5md.observables, n_frames, (1,), "float32", units="kJ/mol"
     )
 
     ind_sort = np.argsort(indices)


### PR DESCRIPTION
Include `ΔH`, the work done by the thermostat rescaling the kinetic energy each time step, in the output. This, together with the total energy, forms the effective Hamiltonian-like constant of motion which should be preserved under NVT simulations with the CSVR thermostat. 

Closes #3 
