### PR TITLE
Fix bug in store_static when bonds are disabled

### DIFF
--- a/hymd/main.py
+++ b/hymd/main.py
@@ -466,9 +466,9 @@ if __name__ == "__main__":
                 bonds_3_stength,
             )
             angle_energy = comm.allreduce(angle_energy_, MPI.SUM)
-    else:
-        # bonds_2_atom1, bonds_2_atom2 = None, None
-        bonds_2_atom1, bonds_2_atom2 = [], []
+        else:
+            # bonds_2_atom1, bonds_2_atom2 = None, None
+            bonds_2_atom1, bonds_2_atom2 = [], []
 
     config.initial_energy = field_energy + kinetic_energy + bond_energy + angle_energy
     out_dataset = OutDataset(args.destdir, config, disable_mpio=args.disable_mpio)


### PR DESCRIPTION
When `--disable-bonds` and `--disable-angle-bonds` are both specified, the `bonds_2_atom1` and `bonds_2_atom2` are now correctly created as empty lists.

Closes #15 