### PR TITLE
Update field, layouts before calculating field force

### DIFF
--- a/hymd/main.py
+++ b/hymd/main.py
@@ -615,7 +615,6 @@ if __name__ == "__main__":
 
         # Update slow forces
         if not args.disable_field:
-            compute_field_energy = np.mod(step + 1, config.n_print) == 0
             update_field(
                 phi,
                 layouts,


### PR DESCRIPTION
Move the update_field call and the recomputing of the layouts list to before the field is calculated in preparation for the secondary outer rRESPA step. 

Fixes #53 and #51 .