### PR TITLE
Remove attempted printing of dipole_forces

### DIFF
--- a/hymd/file_io.py
+++ b/hymd/file_io.py
@@ -622,7 +622,7 @@ def store_data(
         H_tilde = 0.0
 
     header = header_.format(*fmt_)
-    data_fmt = f'{"{:13}"}{15 * "{:13.5g}" }'
+    data_fmt = f'{"{:13}"}{14 * "{:13.5g}" }'
     data = data_fmt.format(
         step,
         time_step * step,

--- a/hymd/main.py
+++ b/hymd/main.py
@@ -424,11 +424,10 @@ def main():
         temperature = (
             (2 / 3) * kinetic_energy / (config.gas_constant * config.n_particles)  # noqa: E501
         )
-        if args.force_output:
-            forces_out = (
-                field_forces + bond_forces + angle_forces + dihedral_forces
-                + reconstructed_forces + dipole_forces
-            )
+        forces_out = (
+            field_forces + bond_forces + angle_forces + dihedral_forces
+            + reconstructed_forces
+        )
         store_data(
             out_dataset, step, frame, indices, positions, velocities,
             forces_out if args.force_output else None, config.box_size,
@@ -752,12 +751,11 @@ def main():
                 )
                 if args.disable_field:
                     field_energy = 0.0
-                if args.force_output:
-                    forces_out = (
-                        field_forces + bond_forces + angle_forces
-                        + dihedral_forces + reconstructed_forces
-                        + dipole_forces
-                    )
+
+                forces_out = (
+                    field_forces + bond_forces + angle_forces
+                    + dihedral_forces + reconstructed_forces
+                )
                 store_data(
                     out_dataset, step, frame, indices, positions, velocities,
                     forces_out if args.force_output else None, config.box_size,
@@ -822,11 +820,10 @@ def main():
         )
         if args.disable_field:
             field_energy = 0.0
-        if args.force_output:
-            forces_out = (
-                field_forces + bond_forces + angle_forces + dihedral_forces
-                + reconstructed_forces + dipole_forces
-            )
+        forces_out = (
+            field_forces + bond_forces + angle_forces + dihedral_forces
+            + reconstructed_forces
+        )
         store_data(
             out_dataset, step, frame, indices, positions, velocities,
             forces_out if args.force_output else None, config.box_size,


### PR DESCRIPTION
Remove `dipole_forces` from the `forces_out` sum of all forces on all particles (it is not a force on particles, despite the name). Also remove extra MD-step log event message item causing errors when attempting to write standard log events.

Closes #143 and #146