### PR TITLE
Fix domain_decomposition bug

### DIFF
--- a/hymd/main.py
+++ b/hymd/main.py
@@ -235,6 +235,23 @@ def main():
             bonds = optional.pop(0)
             molecules = optional.pop(0)
 
+        # rebuild args_in to point to correct arrays
+        args_in = [
+            velocities,
+            indices,
+            bond_forces,
+            angle_forces,
+            dihedral_forces,
+            reconstructed_forces,
+            field_forces,
+            names,
+            types,
+        ]
+
+        if charges_flag:
+            args_in.append(charges)
+            args_in.append(elec_forces)
+
     if not args.disable_field:
         layouts = [pm.decompose(positions[types == t]) for t in range(config.n_types)]  # noqa: E501
         update_field(
@@ -650,6 +667,23 @@ def main():
                 if molecules_flag:
                     bonds = optional.pop(0)
                     molecules = optional.pop(0)
+
+                # rebuild args_in to point to correct arrays
+                args_in = [
+                    velocities,
+                    indices,
+                    bond_forces,
+                    angle_forces,
+                    dihedral_forces,
+                    reconstructed_forces,
+                    field_forces,
+                    names,
+                    types,
+                ]
+
+                if charges_flag:
+                    args_in.append(charges)
+                    args_in.append(elec_forces)
 
                 positions = np.asfortranarray(positions)
                 bond_forces = np.asfortranarray(bond_forces)


### PR DESCRIPTION
This PR closes #184.

The source of the bug was that the arrays returned by `domain_decomposition` had a different memory address than the ones stored in `args_in`.
The solution was to update `args_in` with the values returned by `domain_decomposition`.