### PR TITLE
Rewrite bonded forces routines in C

### DIFF
--- a/hymd/compute_bond_forces.c
+++ b/hymd/compute_bond_forces.c
@@ -1,0 +1,38 @@
+#include <stdio.h>
+#include <math.h>
+
+float cbf(float* f, float* r, float* box, size_t n_bonds, int* a, int* b, float* r0, float* k) {
+    size_t aa, bb;
+    float df, rab_norm, rab[3], fa[3], energy=0.0;
+
+    for (size_t i = 0; i < n_bonds; i++) {
+        aa = 3 * a[i];
+        bb = 3 * b[i];
+
+        rab[0] = r[bb] - r[aa];
+        rab[1] = r[bb + 1] - r[aa + 1];
+        rab[2] = r[bb + 2] - r[aa + 2];
+
+        rab[0] -= box[0] * nearbyint(rab[0]/box[0]);
+        rab[1] -= box[1] * nearbyint(rab[1]/box[1]);
+        rab[2] -= box[2] * nearbyint(rab[2]/box[2]);
+
+        rab_norm = sqrt(rab[0] * rab[0] + rab[1] * rab[1] + rab[2] * rab[2]);
+
+        df = k[i] * (rab_norm - r0[i]);
+        fa[0] = -df * rab[0] / rab_norm;
+        fa[1] = -df * rab[1] / rab_norm;
+        fa[2] = -df * rab[2] / rab_norm;
+
+        f[aa] -= fa[0];
+        f[aa + 1] -= fa[1];
+        f[aa + 2] -= fa[2];
+
+        f[bb] += fa[0];
+        f[bb + 1] += fa[1];
+        f[bb + 2] += fa[2];
+
+        energy += 0.5 * k[i] * pow(rab_norm - r0[i], 2);
+    }
+    return energy;
+}

--- a/hymd/compute_bond_forces.c
+++ b/hymd/compute_bond_forces.c
@@ -13,9 +13,9 @@ float cbf(float* f, float* r, float* box, size_t n_bonds, int* a, int* b, float*
         rab[1] = r[bb + 1] - r[aa + 1];
         rab[2] = r[bb + 2] - r[aa + 2];
 
-        rab[0] -= box[0] * nearbyint(rab[0]/box[0]);
-        rab[1] -= box[1] * nearbyint(rab[1]/box[1]);
-        rab[2] -= box[2] * nearbyint(rab[2]/box[2]);
+        rab[0] -= box[0] * round(rab[0]/box[0]);
+        rab[1] -= box[1] * round(rab[1]/box[1]);
+        rab[2] -= box[2] * round(rab[2]/box[2]);
 
         rab_norm = sqrt(rab[0] * rab[0] + rab[1] * rab[1] + rab[2] * rab[2]);
 

--- a/hymd/compute_bond_forces__double.c
+++ b/hymd/compute_bond_forces__double.c
@@ -1,0 +1,38 @@
+#include <stdio.h>
+#include <math.h>
+
+double cbf(double* f, double* r, double* box, size_t n_bonds, int* a, int* b, double* r0, double* k) {
+    size_t aa, bb;
+    double df, rab_norm, rab[3], fa[3], energy=0.0;
+
+    for (size_t i = 0; i < n_bonds; i++) {
+        aa = 3 * a[i];
+        bb = 3 * b[i];
+
+        rab[0] = r[bb] - r[aa];
+        rab[1] = r[bb + 1] - r[aa + 1];
+        rab[2] = r[bb + 2] - r[aa + 2];
+
+        rab[0] -= box[0] * nearbyint(rab[0]/box[0]);
+        rab[1] -= box[1] * nearbyint(rab[1]/box[1]);
+        rab[2] -= box[2] * nearbyint(rab[2]/box[2]);
+
+        rab_norm = sqrt(rab[0] * rab[0] + rab[1] * rab[1] + rab[2] * rab[2]);
+
+        df = k[i] * (rab_norm - r0[i]);
+        fa[0] = -df * rab[0] / rab_norm;
+        fa[1] = -df * rab[1] / rab_norm;
+        fa[2] = -df * rab[2] / rab_norm;
+
+        f[aa] -= fa[0];
+        f[aa + 1] -= fa[1];
+        f[aa + 2] -= fa[2];
+
+        f[bb] += fa[0];
+        f[bb + 1] += fa[1];
+        f[bb + 2] += fa[2];
+
+        energy += 0.5 * k[i] * pow(rab_norm - r0[i], 2);
+    }
+    return energy;
+}

--- a/hymd/main.py
+++ b/hymd/main.py
@@ -17,7 +17,7 @@ from .field import (compute_field_force, update_field,
                     update_field_force_q, compute_field_energy_q,)
 from .thermostat import (csvr_thermostat, cancel_com_momentum,
                          generate_initial_velocities)
-from .force import dipole_forces_redistribution, prepare_bonds
+from .force import dipole_forces_redistribution, prepare_bonds, wrapped_C_bonded_functions
 from .integrator import integrate_velocity, integrate_position
 
 
@@ -58,6 +58,7 @@ def main():
         from .force import (
             compute_dihedral_forces__fortran as compute_dihedral_forces
         )
+    # compute_bond_forces, compute_angle_forces, compute_dihedral_forces = wrapped_C_bonded_functions(dtype)
 
     driver = "mpio" if not args.disable_mpio else None
     _kwargs = {"driver": driver, "comm": comm} if not args.disable_mpio else {}

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
-import setuptools  # noqa: F401, https://stackoverflow.com/a/55358607/4179419
-from numpy.distutils.core import setup, Extension
+from setuptools import setup, Extension # Don't need to use numpy for compiling C code, I think
 
 
 def find_version(path):
@@ -18,7 +17,7 @@ with open('README.md', 'r') as in_file:
 force_kernels = Extension(
     name="force_kernels",
     sources=[
-        "hymd/compute_bond_forces.f90",
+        "hymd/compute_bond_forces.c",
         "hymd/compute_bond_forces__double.f90",
         "hymd/compute_angle_forces.f90",
         "hymd/compute_angle_forces__double.f90",
@@ -26,6 +25,15 @@ force_kernels = Extension(
         "hymd/compute_dihedral_forces__double.f90",
         "hymd/dipole_reconstruction.f90",
         "hymd/dipole_reconstruction__double.f90",
+    ]
+)
+force_kernels__double = Extension(
+    name="force_kernels__double",
+    sources=[
+        "hymd/compute_bond_forces__double.c",
+        "hymd/compute_angle_forces__double.c",
+        "hymd/compute_dihedral_forces__double.c",
+        "hymd/dipole_reconstruction__double.c",
     ]
 )
 
@@ -40,7 +48,7 @@ setup(
     license="LGPLv3",
     packages=["hymd"],
     version=find_version("hymd/version.py"),
-    ext_modules=[force_kernels],
+    ext_modules=[force_kernels, force_kernels__double],
     setup_requires=[
         "cython",
         "numpy",


### PR DESCRIPTION
This PR potentially closes #11.
Here's the checklist:
- [x] `compute_bond_forces.c`
- [ ] `compute_angle_forces.c`, should be straightforward.
- [ ] `compute_dihedral_forces.c`, might not be that easy (need to implent linear algebra operations that are readily available in Fortran).
- [ ] `dipole_reconstruction.c`, same as for dihedrals.
- [ ] Import methods? As of right now I haven't wrapped the C functions into `PyObjects`, which would allow the usual `from force_kernels import ...` because it kinda looks tedious to do (especially also considering that we are using `NumPy` arrays and it might not be trivial).