### PR TITLE
Add new utils scripts, including one to center a group in the box

### DIFF
--- a/utils/center_group.py
+++ b/utils/center_group.py
@@ -1,0 +1,86 @@
+import os
+import argparse
+import h5py
+import numpy as np
+import re
+
+# based on https://stackoverflow.com/a/6512463/3254658
+def parse_bead_list(string):
+    m = re.match(r'(\d+)(?:-(\d+))?$', string)
+    if not m:
+        raise argparse.ArgumentTypeError("'" + string + "' is not a range of number. Expected forms like '0-5' or '2'.")
+    start = m.group(1)
+    end = m.group(2) or start
+    if int(end) < int(start):
+        raise argparse.ArgumentTypeError(f"Start value ({start}) should be larger than final value ({end})")
+    return list(range(int(start,10), int(end,10)+1))
+
+def get_centers(positions, box):
+    centers = np.empty((0,positions.shape[2]))
+    # based on the position of the first atom get minimal distances
+    for frame in range(positions.shape[0]):
+        deltas = positions[frame,1:,:]-positions[frame,0,:]
+        subtract = np.where(deltas > 0.5 * box, True, False)
+        add = np.where(-deltas > 0.5 * box, True, False)
+
+        newpos = np.where(subtract, positions[frame,1:,:]-box, positions[frame,1:,:])
+        newpos = np.where(add, positions[frame,1:,:]+box, newpos[:,:])
+        newpos = np.insert(newpos, 0, positions[frame,0,:], axis=0)
+        centers = np.append(centers, [newpos.mean(axis=0)], axis=0) # get the centroid
+
+    return centers
+
+def center_trajectory(h5md_file, bead_list, overwrite=False, out_path=None):
+    if out_path is None:
+        out_path = os.path.join(os.path.abspath(os.path.dirname(h5md_file)),
+                                os.path.splitext(os.path.split(h5md_file)[-1])[0]+'_new'
+                               +os.path.splitext(os.path.split(h5md_file)[-1])[1])
+    if os.path.exists(out_path) and not overwrite:
+        error_str = (f'The specified output file {out_path} already exists. '
+                     f'use overwrite=True ("-f" flag) to overwrite.')
+        raise FileExistsError(error_str)
+
+    f_in = h5py.File(h5md_file, 'r')
+    f_out = h5py.File(out_path, 'w')
+
+    for k in f_in.keys():
+        f_in.copy(k, f_out)
+
+    box_size = f_in['particles/all/box/edges'][:]
+
+    beads_pos = f_in['particles/all/position/value'][:][:,bead_list,:]
+    centers = get_centers(beads_pos, box_size)
+
+    translate = (0.5 * box_size) - centers
+
+    translations = np.repeat(translate[:,np.newaxis,:], 
+                             f_in['particles/all/position/value'].shape[1], 
+                             axis=1)
+
+    tpos = f_in['particles/all/position/value'] + translations
+    f_out['particles/all/position/value'][:] = np.mod(tpos, box_size)
+
+    f_in.close()
+    f_out.close()
+
+
+if __name__ == '__main__':
+    description = 'Center geometric center of beads in the box for each frame in a .H5 trajectory'
+    parser = argparse.ArgumentParser(description=description)
+    parser.add_argument('h5md_file', type=str, help='input .H5MD file name')
+    parser.add_argument('--beads', type=parse_bead_list, nargs='+', required=True,
+                        help='bead list to center (e.g.: 1-100 102-150)')
+    parser.add_argument('--out', type=str, default=None, dest='out_path',
+                        metavar='file name', help='output hymd HDF5 file name')
+    parser.add_argument('-f', action='store_true', default=False, dest='force',
+                        help='overwrite existing output file')
+    args = parser.parse_args()
+
+    bead_list = []
+    for interval in args.beads:
+        bead_list += interval
+
+    bead_list = np.array(sorted(bead_list))-1
+
+    center_trajectory(args.h5md_file, bead_list, overwrite=args.force, 
+                      out_path=args.out_path)

--- a/utils/center_group.py
+++ b/utils/center_group.py
@@ -70,7 +70,7 @@ if __name__ == '__main__':
     parser.add_argument('h5md_file', type=str, help='input .H5MD file name')
     parser.add_argument('-b', '--beads', type=parse_bead_list, nargs='+', required=True,
                         help='bead list to center (e.g.: 1-100 102-150)')
-    parser.add_argument('--out', type=str, default=None, dest='out_path',
+    parser.add_argument('-o', '--out', type=str, default=None, dest='out_path',
                         metavar='file name', help='output hymd HDF5 file name')
     parser.add_argument('-f', action='store_true', default=False, dest='force',
                         help='overwrite existing output file')

--- a/utils/center_group.py
+++ b/utils/center_group.py
@@ -9,11 +9,11 @@ def parse_bead_list(string):
     m = re.match(r'(\d+)(?:-(\d+))?$', string)
     if not m:
         raise argparse.ArgumentTypeError("'" + string + "' is not a range of number. Expected forms like '0-5' or '2'.")
-    start = m.group(1)
-    end = m.group(2) or start
-    if int(end) < int(start):
+    start = int(m.group(1), base=10)
+    end = int(m.group(2), base=10) or start
+    if end < start:
         raise argparse.ArgumentTypeError(f"Start value ({start}) should be larger than final value ({end})")
-    return list(range(int(start,10), int(end,10)+1))
+    return list(range(start, end + 1))
 
 def get_centers(positions, box):
     centers = np.empty((0,positions.shape[2]))

--- a/utils/center_group.py
+++ b/utils/center_group.py
@@ -68,7 +68,7 @@ if __name__ == '__main__':
     description = 'Center geometric center of beads in the box for each frame in a .H5 trajectory'
     parser = argparse.ArgumentParser(description=description)
     parser.add_argument('h5md_file', type=str, help='input .H5MD file name')
-    parser.add_argument('--beads', type=parse_bead_list, nargs='+', required=True,
+    parser.add_argument('-b', '--beads', type=parse_bead_list, nargs='+', required=True,
                         help='bead list to center (e.g.: 1-100 102-150)')
     parser.add_argument('--out', type=str, default=None, dest='out_path',
                         metavar='file name', help='output hymd HDF5 file name')

--- a/utils/nm2a_h5md.py
+++ b/utils/nm2a_h5md.py
@@ -1,0 +1,41 @@
+import os
+import argparse
+import h5py
+import numpy as np
+
+def nm2a_h5md(h5md_file, overwrite=False, out_path=None):
+    if out_path is None:
+        out_path = os.path.join(os.path.abspath(os.path.dirname(h5md_file)),
+                                os.path.splitext(os.path.split(h5md_file)[-1])[0]+'_ang'
+                               +os.path.splitext(os.path.split(h5md_file)[-1])[1])
+    if os.path.exists(out_path) and not overwrite:
+        error_str = (f'The specified output file {out_path} already exists. '
+                     f'use overwrite=True ("-f" flag) to overwrite.')
+        raise FileExistsError(error_str)
+
+    f_in = h5py.File(h5md_file, 'r')
+    f_out = h5py.File(out_path, 'w')
+
+    for k in f_in.keys():
+        f_in.copy(k, f_out)
+
+    box_size = f_in['particles/all/box/edges'][:] * 10.
+    f_out['particles/all/box/edges'][:] = box_size
+
+    tpos = f_in['particles/all/position/value'][:] * 10.
+    f_out['particles/all/position/value'][:] = np.mod(tpos, box_size)
+
+    f_in.close()
+    f_out.close()
+
+if __name__ == '__main__':
+    description = 'Convert .H5 file coordinates from nm to A'
+    parser = argparse.ArgumentParser(description=description)
+    parser.add_argument('h5md_file', type=str, help='input .H5MD file name')
+    parser.add_argument('--out', type=str, default=None, dest='out_path',
+                        metavar='file name', help='output hymd HDF5 file name')
+    parser.add_argument('-f', action='store_true', default=False, dest='force',
+                        help='overwrite existing output file')
+    args = parser.parse_args()
+
+    nm2a_h5md(args.h5md_file, overwrite=args.force, out_path=args.out_path)

--- a/utils/pdb2hdf5.py
+++ b/utils/pdb2hdf5.py
@@ -1,0 +1,170 @@
+import os
+import argparse
+import h5py
+import math
+import numpy as np
+from openbabel import openbabel
+# openbabel.obErrorLog.SetOutputLevel(0) # uncomment to suppress warnings
+
+def extant_file(x):
+    """
+    'Type' for argparse - checks that file exists but does not open.
+    From https://stackoverflow.com/a/11541495
+    """
+    if not os.path.exists(x):
+        # Argparse uses the ArgumentTypeError to give a rejection message like:
+        # error: argument input: x does not exist
+        raise argparse.ArgumentTypeError("{0} does not exist".format(x))
+    return x
+
+def a2nm(x):
+    return x/10.
+
+def pdb_to_input(pdb_file, charges=None, bonds=None, out_path=None, overwrite=False):
+    if out_path is None:
+        out_path = os.path.join(os.path.abspath(os.path.dirname(pdb_file)),
+                                os.path.splitext(pdb_file)[0]+".hdf5")
+    if os.path.exists(out_path) and not overwrite:
+        error_str = (f'The specified output file {out_path} already exists. '
+                     f'use overwrite=True ("-f" flag) to overwrite.')
+        raise FileExistsError(error_str)
+
+    # read charges
+    if charges:
+        charge_dict = {}
+        with open(charges, "r") as f:
+            for line in f:
+                beadtype, beadchrg = line.split()
+                charge_dict[beadtype] = float(beadchrg)
+
+    # read bonds
+    if bonds:
+        bonds_list = []
+        with open(bonds, "r") as f:
+            for line in f:
+                bnd1 = "{} {}".format(line.split()[0], line.split()[1])
+                bnd2 = "{} {}".format(line.split()[1], line.split()[0])
+                bonds_list.append(bnd1)
+                bonds_list.append(bnd2)
+
+    obConversion = openbabel.OBConversion()
+    obConversion.SetInAndOutFormats("pdb","xyz")
+    # ignore ring perception and CONECTs for faster processing
+    obConversion.AddOption("b", openbabel.OBConversion.INOPTIONS) 
+    obConversion.AddOption("c", openbabel.OBConversion.INOPTIONS)
+
+    # read molecule to OBMol object
+    mol = openbabel.OBMol()
+    obConversion.ReadFile(mol, pdb_file)
+    if not bonds:
+        mol.ConnectTheDots() # necessary because of the 'b' INOPTION
+    n_particles = mol.NumAtoms()
+
+    # get atomic labels from pdb
+    atom_to_lbl = {}
+    for res in openbabel.OBResidueIter(mol):
+        for atom in openbabel.OBResidueAtomIter(res):
+            atom_to_lbl[atom.GetId()] = res.GetAtomID(atom).strip()
+
+    # from label to type
+    lbl_to_type = {}
+    for i, lbl in enumerate(set(atom_to_lbl.values())):
+        lbl_to_type[lbl] = i
+
+    # if bonds per residue are passed, connect atoms
+    for res in openbabel.OBResidueIter(mol):
+        for atom1 in openbabel.OBResidueAtomIter(res):
+            for atom2 in openbabel.OBResidueAtomIter(res):
+                id1, id2 = atom1.GetId(), atom2.GetId()
+                if id1 == id2: 
+                    continue
+                if "{} {}".format(atom_to_lbl[id1], atom_to_lbl[id2]) in bonds_list:
+                    mol.AddBond(id1+1, id2+1, 1)
+
+    molecules = mol.Separate()
+    n_molecules = len(molecules)
+
+    # detect the molecules types
+    atom_to_mol = {}
+    for i, submol in enumerate(molecules):
+        for at in openbabel.OBMolAtomIter(submol):
+            atom_to_mol[at.GetId()] = i
+
+    # write the topology
+    with h5py.File(out_path, "w") as out_file:
+        position_dataset = out_file.create_dataset(
+            "coordinates",
+            (1, n_particles, 3,),
+            dtype="float32",
+        )
+        types_dataset = out_file.create_dataset(
+            "types",
+            (n_particles,),
+            dtype="i",
+        )
+        names_dataset = out_file.create_dataset(
+            "names",
+            (n_particles,),
+            dtype="S10",
+        )
+        indices_dataset = out_file.create_dataset(
+            "indices",
+            (n_particles,),
+            dtype="i",
+        )
+        molecules_dataset = out_file.create_dataset(
+            "molecules",
+            (n_particles,),
+            dtype="i",
+        )
+        bonds_dataset = out_file.create_dataset(
+            "bonds",
+            (n_particles, 4,),
+            dtype="i",
+        )
+        if charges:
+            charges_dataset = out_file.create_dataset(
+            "charge",
+            (n_particles,),
+            dtype="float32",
+            )
+
+        bonds_dataset[...] = -1
+        for i, atom in enumerate(openbabel.OBMolAtomIter(mol)):
+            indices_dataset[i] = i
+            position_dataset[0, i, :] = np.array(
+                                        [a2nm(atom.GetX()),
+                                        a2nm(atom.GetY()),
+                                        a2nm(atom.GetZ())],
+                                        dtype=np.float32
+                                        )
+            charges_dataset[i] = charge_dict[atom_to_lbl[atom.GetId()]]
+            molecules_dataset[i] = atom_to_mol[atom.GetId()]
+            names_dataset[i] = np.string_(atom_to_lbl[atom.GetId()])
+            types_dataset[i] = lbl_to_type[atom_to_lbl[atom.GetId()]]
+            for j, nbr in enumerate(openbabel.OBAtomAtomIter(atom)):
+                bonds_dataset[i, j] = nbr.GetId()
+
+
+if __name__ == '__main__':
+    description = 'Convert .pdb files to the hymd hdf5 input format'
+    parser = argparse.ArgumentParser(description=description)
+    parser.add_argument('pdb_file', type=extant_file, help='input .pdb file name')
+    parser.add_argument('--charges', type=extant_file, default=None,
+                        help='file containing the charge for each atom type')
+    parser.add_argument('--bonds', type=extant_file, default=None,
+                        help='file containing the connected beads for each residue')
+    parser.add_argument('--out', type=str, default=None, dest='out_path',
+                        metavar='file name', help='output hymd HDF5 file name')
+    parser.add_argument('-f', action='store_true', default=False, dest='force',
+                        help='overwrite existing output file')
+    args = parser.parse_args()
+
+    # get basename and file extension
+    base, ext = os.path.splitext(args.pdb_file)
+
+    # check input consistency
+    if ext.lower()[1:] != "pdb":
+        parser.error("pdb_file extension is not .pdb")
+
+    pdb_to_input(args.pdb_file, charges=args.charges, bonds=args.bonds, out_path=args.out_path, overwrite=args.force)


### PR DESCRIPTION
This PR closes #187.

I added 3 new scripts to utils:

- `center_group.py` works by passing a group of beads, e.g. `1-1234` or `1 3 6-100`, calculates the centroid of this group of atoms for each frame, and, finally, centers this group in the box. The final trajectory has the group in the center of the box in each frame of the trajectory.
- `nm2a_h5md.py` converts coordinates from nm to angstrom for a `.H5` output trajectory.
- `pdb2hdf5.py` receives a `.pdb` and based on `.txt` files with charges, connectivity etc, generates a `.hdf5` input.