### PR TITLE
Fix electrostatic energy

### DIFF
--- a/hymd/file_io.py
+++ b/hymd/file_io.py
@@ -604,7 +604,7 @@ def store_data(
     ]
     fmt_ = np.array(fmt_)
     
-    # create mask to show only energies > 0
+    # create mask to show only energies != 0
     en_array = np.array([
         field_energy,
         field_q_energy,
@@ -613,7 +613,7 @@ def store_data(
         bond4_energy,
     ])
     mask = np.full_like(fmt_, True, dtype=bool)
-    mask[range(6,11)] = en_array > 0.
+    mask[range(6,11)] = en_array != 0.
 
     header_ = fmt_[mask].shape[0] * "{:>13}"
     if config.initial_energy is None:

--- a/hymd/file_io.py
+++ b/hymd/file_io.py
@@ -59,13 +59,24 @@ class OutDataset:
                 comm=comm
             )
 
+    def is_open(self, comm=MPI.COMM_WORLD):
+        """Check if HDF5 output file is open
+
+        Parameters
+        ----------
+        comm : mpi4py.Comm
+            MPI communicator to use for rank communication.
+        """
+        comm.Barrier()
+        return self.file.__bool__()
+
     def close_file(self, comm=MPI.COMM_WORLD):
         """Closes the HDF5 output file
 
         Parameters
         ----------
         comm : mpi4py.Comm
-            MPI communicator to use for rank commuication.
+            MPI communicator to use for rank communication.
         """
         comm.Barrier()
         self.file.close()
@@ -208,6 +219,8 @@ def store_static(
     if np.mod(config.n_steps - 1, config.n_print) != 0:
         n_frames += 1
     if np.mod(config.n_steps, config.n_print) == 1:
+        n_frames += 1
+    if n_frames == config.n_steps:
         n_frames += 1
 
     species = h5md.all_particles.create_dataset(

--- a/hymd/input_parser.py
+++ b/hymd/input_parser.py
@@ -149,7 +149,7 @@ class Config:
         Four-particle bond type dataclass.
     """
     gas_constant: ClassVar[float] = 0.0083144621  # kJ mol-1 K-1
-    coulomb_constant: ClassVar[float] = 138.935458  # kJ mn mol-1 e-2
+    coulomb_constant: ClassVar[float] = 138.935458  # kJ nm mol-1 e-2
 
     n_steps: int
     time_step: float

--- a/hymd/main.py
+++ b/hymd/main.py
@@ -175,7 +175,10 @@ def main():
         elec_field = [
             pm.create("real", value=0.0) for _ in range(_SPACE_DIM)
         ]  # for force calculation
-        elec_energy_field = pm.create(
+        elec_potential = pm.create(
+            "real", value=0.0
+        )
+        elec_potential_fourier = pm.create(
             "complex", value=0.0
         )
 
@@ -264,11 +267,12 @@ def main():
         layout_q = pm.decompose(positions)
         update_field_force_q(
             charges, phi_q, phi_q_fourier, elec_field_fourier, elec_field,
-            elec_forces, layout_q, pm, positions, config,
+            elec_forces, layout_q, hamiltonian, pm, positions, config,
         )
 
         field_q_energy = compute_field_energy_q(
-            config, phi_q_fourier, elec_energy_field, field_q_energy,
+            config, phi_q, phi_q_fourier, elec_potential, 
+            elec_potential_fourier, 
             field_q_self_energy, comm=comm,
         )
 
@@ -376,7 +380,7 @@ def main():
             update_field_force_q(
                 dipole_charges, phi_dipoles, phi_dipoles_fourier,
                 dipoles_field_fourier, dipoles_field, dipole_forces,
-                layout_dipoles, pm, dipole_positions, config,
+                layout_dipoles, hamiltonian, pm, dipole_positions, config,
             )
 
             dipole_positions = np.reshape(dipole_positions, (n_tors, 4, 3))
@@ -566,10 +570,12 @@ def main():
                 layout_q = pm.decompose(positions)
                 update_field_force_q(
                     charges, phi_q, phi_q_fourier, elec_field_fourier,
-                    elec_field, elec_forces, layout_q, pm, positions, config,
+                    elec_field, elec_forces, layout_q, hamiltonian, 
+                    pm, positions, config,
                 )
                 field_q_energy = compute_field_energy_q(
-                    config, phi_q_fourier, elec_energy_field, field_q_energy,
+                    config, phi_q, phi_q_fourier, elec_potential, 
+                    elec_potential_fourier, 
                     field_q_self_energy, comm=comm,
                 )
 
@@ -585,7 +591,7 @@ def main():
                 update_field_force_q(
                     dipole_charges, phi_dipoles, phi_dipoles_fourier,
                     dipoles_field_fourier, dipoles_field, dipole_forces,
-                    layout_dipoles, pm, dipole_positions, config,
+                    layout_dipoles, hamiltonian, pm, dipole_positions, config,
                 )
 
                 dipole_positions = np.reshape(dipole_positions, (n_tors, 4, 3))
@@ -767,8 +773,9 @@ def main():
 
                     if charges_flag and config.coulombtype == "PIC_Spectral":
                         field_q_energy = compute_field_energy_q(
-                            config, phi_q_fourier, elec_energy_field,
-                            field_q_energy, field_q_self_energy, comm=comm,
+                            config, phi_q, phi_q_fourier, elec_potential, 
+                            elec_potential_fourier, 
+                            field_q_self_energy, comm=comm,
                         )
                 else:
                     kinetic_energy = comm.allreduce(
@@ -831,11 +838,13 @@ def main():
                 layout_q = pm.decompose(positions)
                 update_field_force_q(
                     charges, phi_q, phi_q_fourier, elec_field_fourier,
-                    elec_field, elec_forces, layout_q, pm, positions, config,
+                    elec_field, elec_forces, layout_q, hamiltonian, pm,
+                    positions, config,
                 )
 
                 field_q_energy = compute_field_energy_q(
-                    config, phi_q_fourier, elec_energy_field, field_q_energy,
+                    config, phi_q, phi_q_fourier, elec_potential, 
+                    elec_potential_fourier, 
                     field_q_self_energy, comm=comm,
                 )
 

--- a/hymd/main.py
+++ b/hymd/main.py
@@ -134,6 +134,7 @@ def main():
     dihedral_energy = 0.0
     kinetic_energy = 0.0
     field_q_energy = 0.0
+    field_q_self_energy = 0.0
 
     # Ignore numpy numpy.VisibleDeprecationWarning: Creating an ndarray from
     # ragged nested sequences until it is fixed in pmesh

--- a/hymd/main.py
+++ b/hymd/main.py
@@ -15,7 +15,8 @@ from .logger import Logger, format_timedelta
 from .file_io import distribute_input, OutDataset, store_static, store_data
 from .field import (compute_field_force, update_field,
                     compute_field_and_kinetic_energy, domain_decomposition,
-                    update_field_force_q, compute_field_energy_q,)
+                    update_field_force_q, compute_field_energy_q,
+                    compute_self_energy_q)
 from .thermostat import (csvr_thermostat, cancel_com_momentum,
                          generate_initial_velocities)
 from .force import dipole_forces_redistribution, prepare_bonds
@@ -258,6 +259,7 @@ def main():
         )
 
     if charges_flag and config.coulombtype == "PIC_Spectral":
+        field_q_self_energy = compute_self_energy_q(config, charges, comm=comm)
         layout_q = pm.decompose(positions)
         update_field_force_q(
             charges, phi_q, phi_q_fourier, elec_field_fourier, elec_field,
@@ -266,7 +268,7 @@ def main():
 
         field_q_energy = compute_field_energy_q(
             config, phi_q_fourier, elec_energy_field, field_q_energy,
-            comm=comm,
+            field_q_self_energy, comm=comm,
         )
 
     if molecules_flag:
@@ -567,7 +569,7 @@ def main():
                 )
                 field_q_energy = compute_field_energy_q(
                     config, phi_q_fourier, elec_energy_field, field_q_energy,
-                    comm=comm,
+                    field_q_self_energy, comm=comm,
                 )
 
             if protein_flag and not args.disable_dipole:
@@ -765,7 +767,7 @@ def main():
                     if charges_flag and config.coulombtype == "PIC_Spectral":
                         field_q_energy = compute_field_energy_q(
                             config, phi_q_fourier, elec_energy_field,
-                            field_q_energy, comm=comm,
+                            field_q_energy, field_q_self_energy, comm=comm,
                         )
                 else:
                     kinetic_energy = comm.allreduce(
@@ -833,7 +835,7 @@ def main():
 
                 field_q_energy = compute_field_energy_q(
                     config, phi_q_fourier, elec_energy_field, field_q_energy,
-                    comm=comm,
+                    field_q_self_energy, comm=comm,
                 )
 
         else:

--- a/utils/plot_traj.py
+++ b/utils/plot_traj.py
@@ -11,8 +11,9 @@ def parse_args():
             "Extracts observables from H5MD files and plots them "
             "using matplotlib. Supported properties: Total energy "
             "(E), potential energy (PE), kinetic energy (KE), bond "
-            "energy (BE), angular bond energy (AE), and total center "
-            "of mass momentum (P). Plot all available observables by "
+            "energy (BE), angular bond energy (AE), total center "
+            "of mass momentum (P), and electrostatic energy (EE). "
+            "Plot all available observables by "
             'specifying "all".'
         )
     )
@@ -22,7 +23,7 @@ def parse_args():
         type=str,
         nargs="+",
         help="Properties to plot",
-        choices=["E", "PE", "KE", "BE", "FE", "AE", "P", "all"],
+        choices=["E", "PE", "KE", "BE", "FE", "AE", "P", "EE", "all"],
     )  # noqa: E501
     parser.add_argument("--file", type=str, default="sim.h5", help="H5MD file")
     parser.add_argument(
@@ -161,7 +162,7 @@ class Property:
 if __name__ == "__main__":
     args = parse_args()
     if "all" in args.property:
-        args.property = ["E", "PE", "KE", "BE", "FE", "AE", "DE", "P"]
+        args.property = ["E", "PE", "KE", "BE", "FE", "AE", "DE", "P", "EE"]
     file_path = os.path.abspath(args.file)
     h5md_file = open_h5md_file(file_path)
 


### PR DESCRIPTION
This PR fixes the way electrostatic energy was computed. The previous expression was wrong, so a new correct expression was implemented.
Now, we also consider the self-interaction energy and subtract it properly.

While I was at it, I fixed the dataset size when n_print = 1 and the printing of energy to screen when the energy was < 0.
I also fixed #144 while I was doing some cleanup and adding comments to make the code more readable.
