### PR TITLE
Fix NPT simulations without electrostatics

### DIFF
--- a/hymd/hamiltonian.py
+++ b/hymd/hamiltonian.py
@@ -171,6 +171,13 @@ class SquaredPhi(Hamiltonian):
         ):
             return type_charges[t] * psi
 
+        self.V_bar_0 = [
+            sympy.lambdify(
+                [(self.phi)], V_bar_0(self.phi, t)
+            )
+            for t in range(self.config.n_types)
+        ]
+
         self.V_bar = [
             sympy.lambdify(
                 [(self.phi, self.psi)], V_bar_0(self.phi, t) + V_bar_elec(self.psi, t)
@@ -278,6 +285,13 @@ class DefaultNoChi(Hamiltonian):
             type_charges=self.config.type_charges,
         ):
             return type_charges[t] * psi
+
+        self.V_bar_0 = [
+            sympy.lambdify(
+                [(self.phi)], V_bar_0(self.phi, t)
+            )
+            for t in range(self.config.n_types)
+        ]
 
         self.V_bar = [
             sympy.lambdify(
@@ -438,6 +452,13 @@ class DefaultWithChi(Hamiltonian):
             type_charges=self.config.type_charges,
         ):
             return type_charges[t] * psi
+
+        self.V_bar_0 = [
+            sympy.lambdify(
+                [(self.phi)], V_bar_0(self.phi, t)
+            )
+            for t in range(self.config.n_types)
+        ]
 
         self.V_bar = [
             sympy.lambdify(

--- a/hymd/pressure.py
+++ b/hymd/pressure.py
@@ -101,7 +101,10 @@ def comp_pressure(
     p0 = -1 / V * np.sum(w)
 
     # Term 2
-    V_bar = np.array([hamiltonian.V_bar[k]([phi, psi]) for k in range(config.n_types)])
+    if psi is not None: # if using electrostatics
+        V_bar = np.array([hamiltonian.V_bar[k]([phi, psi]) for k in range(config.n_types)])
+    else:
+        V_bar = np.array([hamiltonian.V_bar_0[k](phi) for k in range(config.n_types)])
 
     p1 = np.sum((volume_per_cell / V) * V_bar * phi)
 


### PR DESCRIPTION
Fixes an error where `sympy` complained about `psi = None`.