### PR TITLE
Fix dihedral parsing in topology and undefined dihedral angles

### DIFF
--- a/hymd/compute_dihedral_forces.f90
+++ b/hymd/compute_dihedral_forces.f90
@@ -48,7 +48,11 @@ subroutine cdf(force, r, dipoles, transfer_matrix, box, a, b, c, d, coeff, dtype
 
     cos_phi = dot_product(v, w)
     sin_phi = dot_product(w, f) * g_norm
-    phi = atan2(sin_phi, cos_phi)
+    if (cos_phi == 0.0 .and. sin_phi == 0.0) then
+      continue
+    else
+      phi = atan2(sin_phi, cos_phi)
+    endif
 
     f_dot_g = dot_product(f, g)
     h_dot_g = dot_product(h, g)


### PR DESCRIPTION
When ` -p` was used, the dihedral parsing was bugged, not supporting all the possible options.
Now, we also skip computing angles and forces when the dihedral is undefined.