### PR TITLE
Fix release action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
         python3 -m pip install --upgrade pip
         python3 -m pip install --upgrade wheel numpy mpi4py "cython<3"
         CC="mpicc" HDF5_MPI="ON" python3 -m pip install --no-binary=h5py h5py
-        python3 -m pip install pmesh @ git+https://github.com/rainwoodman/pmesh
+        python3 -m pip install "pmesh @ git+https://github.com/rainwoodman/pmesh"
         python3 -m pip install -r requirements.txt
     - name: Install PLUMED
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,7 @@ jobs:
         python3 -m pip install --upgrade pip
         python3 -m pip install --upgrade wheel numpy mpi4py "cython<3"
         CC="mpicc" HDF5_MPI="ON" python3 -m pip install --no-binary=h5py h5py
+        python3 -m pip install pmesh @ git+https://github.com/rainwoodman/pmesh
         python3 -m pip install -r requirements.txt
     - name: Install PLUMED
       run: |

--- a/.github/workflows/docs_pages.yml
+++ b/.github/workflows/docs_pages.yml
@@ -32,6 +32,7 @@ jobs:
       run: |
         python3 -m pip install --upgrade pip
         python3 -m pip install --upgrade wheel numpy mpi4py "cython<3"
+        python3 -m pip install pmesh @ git+https://github.com/rainwoodman/pmesh
         python3 -m pip install -r requirements.txt
     - name: Install package
       run: |

--- a/.github/workflows/docs_pages.yml
+++ b/.github/workflows/docs_pages.yml
@@ -32,7 +32,7 @@ jobs:
       run: |
         python3 -m pip install --upgrade pip
         python3 -m pip install --upgrade wheel numpy mpi4py "cython<3"
-        python3 -m pip install pmesh @ git+https://github.com/rainwoodman/pmesh
+        python3 -m pip install "pmesh @ git+https://github.com/rainwoodman/pmesh"
         python3 -m pip install -r requirements.txt
     - name: Install package
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,7 @@ jobs:
       run: |
         python3 -m pip install --upgrade pip
         python3 -m pip install --upgrade wheel numpy mpi4py "cython<3" twine setuptools
+        python3 -m pip install pmesh @ git+https://github.com/rainwoodman/pmesh
         python3 -m pip install -r requirements.txt
     - name: Build and publish
       env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       run: |
         python3 -m pip install --upgrade pip
         python3 -m pip install --upgrade wheel numpy mpi4py "cython<3" twine setuptools
-        python3 -m pip install pmesh @ git+https://github.com/rainwoodman/pmesh
+        python3 -m pip install "pmesh @ git+https://github.com/rainwoodman/pmesh"
         python3 -m pip install -r requirements.txt
     - name: Build and publish
       env:

--- a/README.md
+++ b/README.md
@@ -46,8 +46,10 @@ CC="mpicc" HDF5_MPI="ON" python3 -m pip install --no-binary=h5py h5py
 Install HyMD with `pip` by
 ```bash
 python3 -m pip install --upgrade numpy mpi4py cython
+python3 -m pip install pmesh @ git+https://github.com/rainwoodman/pmesh
 python3 -m pip install hymd
 ```
+`pmesh` is installed from the GitHub repository because fixes to be compatible with modern NumPy versions were not pushed to PyPI.
 See [HyMD docs](https://cascella-group-uio.github.io/HyMD/doc_pages/installation.html) for more information, including install steps for macOS and non-Debian linux distributions.
 
 #### Run in docker

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ CC="mpicc" HDF5_MPI="ON" python3 -m pip install --no-binary=h5py h5py
 Install HyMD with `pip` by
 ```bash
 python3 -m pip install --upgrade numpy mpi4py cython
-python3 -m pip install pmesh @ git+https://github.com/rainwoodman/pmesh
+python3 -m pip install "pmesh @ git+https://github.com/rainwoodman/pmesh"
 python3 -m pip install hymd
 ```
 `pmesh` is installed from the GitHub repository because fixes to be compatible with modern NumPy versions were not pushed to PyPI.

--- a/docs/doc_pages/installation.rst
+++ b/docs/doc_pages/installation.rst
@@ -77,6 +77,7 @@ Dependencies
            python3 -m pip install --upgrade pip
            CC="mpicc" HDF5_MPI="ON" python3 -m pip install --no-binary=h5py h5py
            python3 -m pip install mpi4py numpy cython
+           python3 -m pip install pmesh @ git+https://github.com/rainwoodman/pmesh
 
 
    .. group-tab:: Fedora (dnf)
@@ -88,6 +89,7 @@ Dependencies
           python3.9 -m pip install mpi4py numpy cython
           export HDF5_DIR="/usr/lib64/openmpi/"
           CC="mpicc" HDF5_MPI="ON" python3.9 -m pip install --no-binary=h5py h5py
+          python3.9 -m pip install pmesh @ git+https://github.com/rainwoodman/pmesh
 
    .. group-tab:: Mac OSX (brew)
 
@@ -112,6 +114,7 @@ Dependencies
            export HDF5_DIR="/usr/local/Cellar/hdf5-mpi/1.13.0/"
            CC="mpicc" HDF5_MPI="ON" python3 -m pip install --no-binary=h5py h5py
            python3 -m pip install mpi4py numpy cython
+           python3 -m pip install pmesh @ git+https://github.com/rainwoodman/pmesh
 
 
 .. warning::

--- a/docs/doc_pages/installation.rst
+++ b/docs/doc_pages/installation.rst
@@ -77,7 +77,7 @@ Dependencies
            python3 -m pip install --upgrade pip
            CC="mpicc" HDF5_MPI="ON" python3 -m pip install --no-binary=h5py h5py
            python3 -m pip install mpi4py numpy cython
-           python3 -m pip install pmesh @ git+https://github.com/rainwoodman/pmesh
+           python3 -m pip install "pmesh @ git+https://github.com/rainwoodman/pmesh"
 
 
    .. group-tab:: Fedora (dnf)
@@ -89,7 +89,7 @@ Dependencies
           python3.9 -m pip install mpi4py numpy cython
           export HDF5_DIR="/usr/lib64/openmpi/"
           CC="mpicc" HDF5_MPI="ON" python3.9 -m pip install --no-binary=h5py h5py
-          python3.9 -m pip install pmesh @ git+https://github.com/rainwoodman/pmesh
+          python3.9 -m pip install "pmesh @ git+https://github.com/rainwoodman/pmesh"
 
    .. group-tab:: Mac OSX (brew)
 
@@ -114,7 +114,7 @@ Dependencies
            export HDF5_DIR="/usr/local/Cellar/hdf5-mpi/1.13.0/"
            CC="mpicc" HDF5_MPI="ON" python3 -m pip install --no-binary=h5py h5py
            python3 -m pip install mpi4py numpy cython
-           python3 -m pip install pmesh @ git+https://github.com/rainwoodman/pmesh
+           python3 -m pip install "pmesh @ git+https://github.com/rainwoodman/pmesh"
 
 
 .. warning::

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ tomli
 cython<3
 mpsort
 pfft-python
-pmesh @ git+https://github.com/rainwoodman/pmesh
+pmesh


### PR DESCRIPTION
Changes the `pmesh` requirement in `requirements.txt` to enable releasing to PyPI.
Also, updated installation instructions to reflect this change.